### PR TITLE
Correcting gutenberg.net to gutenberg.org

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -5,7 +5,7 @@ The works in this repository are licensed under the MIT License, with the except
 > This eBook is for the use of anyone anywhere at no cost and with
 > almost no restrictions whatsoever.  You may copy it, give it away or
 > re-use it under the terms of the Project Gutenberg License included
-> with this eBook or online at www.gutenberg.net
+> with this eBook or online at www.gutenberg.org
 
 
 # License for derivative works

--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ From Project Gutenberg:
 > This eBook is for the use of anyone anywhere at no cost and with
 > almost no restrictions whatsoever.  You may copy it, give it away or
 > re-use it under the terms of the Project Gutenberg License included
-> with this eBook or online at www.gutenberg.net
+> with this eBook or online at www.gutenberg.org


### PR DESCRIPTION
gutenberg.net is a VERY different site than gutenberg.org. Just changed a couple of references to correct.
